### PR TITLE
Fix statistics calculation for cases with contained annotations

### DIFF
--- a/res/samples/other/duplicates_equals.ann
+++ b/res/samples/other/duplicates_equals.ann
@@ -1,0 +1,3 @@
+T1	Concept 0 16	something inside
+T2	Concept 0 16	something inside
+T3	Concept 10 16	inside

--- a/res/samples/other/duplicates_equals_b.ann
+++ b/res/samples/other/duplicates_equals_b.ann
@@ -1,0 +1,3 @@
+T1	Concept 0 16	something inside
+T2	Concept 0 16	something inside
+T3	Concept 10 16	inside

--- a/res/samples/other/incorrect.ann
+++ b/res/samples/other/incorrect.ann
@@ -1,0 +1,1 @@
+T1	Concept 0 16	something inside

--- a/res/samples/other/incorrect_b.ann
+++ b/res/samples/other/incorrect_b.ann
@@ -1,0 +1,1 @@
+T1	Other 0 16	something inside

--- a/res/samples/other/incorrect_duplicate_mix.ann
+++ b/res/samples/other/incorrect_duplicate_mix.ann
@@ -1,0 +1,1 @@
+T1	Concept 0 16	something inside

--- a/res/samples/other/incorrect_duplicate_mix_b.ann
+++ b/res/samples/other/incorrect_duplicate_mix_b.ann
@@ -1,0 +1,2 @@
+T1	Other 0 16	something inside
+T2	Concept 0 16	something inside

--- a/res/samples/other/no_overlaps_equals.ann
+++ b/res/samples/other/no_overlaps_equals.ann
@@ -1,0 +1,2 @@
+T1	Concept 0 16	something inside
+T2	Concept 10 16	inside

--- a/res/samples/other/no_overlaps_equals_b.ann
+++ b/res/samples/other/no_overlaps_equals_b.ann
@@ -1,0 +1,2 @@
+T1	Concept 0 16	something inside
+T2	Concept 10 16	inside

--- a/res/samples/other/partial.ann
+++ b/res/samples/other/partial.ann
@@ -1,0 +1,1 @@
+T1	Concept 0 16	something inside

--- a/res/samples/other/partial_b.ann
+++ b/res/samples/other/partial_b.ann
@@ -1,0 +1,1 @@
+T1	Concept 10 16	inside

--- a/res/samples/other/partial_different.ann
+++ b/res/samples/other/partial_different.ann
@@ -1,0 +1,1 @@
+T1	Concept 0 16	something inside

--- a/res/samples/other/partial_different_b.ann
+++ b/res/samples/other/partial_different_b.ann
@@ -1,0 +1,1 @@
+T1	Other 0 9	something


### PR DESCRIPTION
As discussed in #1, the statistics are not properly calculated when pointing to the same file.

After analysing the source code and the test samples, I figured out that an annotation is compared with all the annotations included on it. This may not be the right way to it. Let's see the following case:

**gold document**

```
T1  Concept 0 16    something inside
T2  Concept 10 16   inside
```

**other document**

```
T1  Concept 0 16    something inside
T2  Concept 10 16   inside
```

As the T2 is included in T1, the comparison for T1 would be done for T1 and T2, which results in a correct and a partially correct annotation. In fact, this would result in 3 total comparisons, instead of 2.

So, I first remove the duplicates (so T1 wouldn't compare twice if there is an equal annotation). Then, check for equal annotations. If there isn't an equal annotation, then it checks for contained annotations for comparison.

I also uploaded a bunch of samples, which seem to be producing the expected results for me.

Here's a small script to run the samples

```
from bratutils import agreement as a

doc = a.Document('res/samples/A/data-sample-1.ann')
doc2 = a.Document('res/samples/A/data-sample-1.ann')

#doc = a.Document('res/samples/other/duplicates_equals.ann')
#doc2 = a.Document('res/samples/other/duplicates_equals_b.ann')

#doc = a.Document('res/samples/other/incorrect.ann')
#doc2 = a.Document('res/samples/other/incorrect_b.ann')

#doc = a.Document('res/samples/other/incorrect_duplicate_mix.ann')
#doc2 = a.Document('res/samples/other/incorrect_duplicate_mix_b.ann')

#doc = a.Document('res/samples/other/no_overlaps_equals.ann')
#doc2 = a.Document('res/samples/other/no_overlaps_equals_b.ann')

#doc = a.Document('res/samples/other/partial.ann')
#doc2 = a.Document('res/samples/other/partial_b.ann')

#doc = a.Document('res/samples/other/partial_different.ann')
#doc2 = a.Document('res/samples/other/partial_different_b.ann')

doc.make_gold()
statistics = doc2.compare_to_gold(doc)

print statistics
```

Please, analyse the changes and check if this really is the desired output.
Thanks.
