### PR TITLE
Parsing annotation types more gracefully

### DIFF
--- a/res/tests/unsupporteddoc.ann
+++ b/res/tests/unsupporteddoc.ann
@@ -1,0 +1,49 @@
+T1	N 0 7	Delilah
+#1	Lemma T1	 Delilah
+A1	SUBCAT T1 Prop
+A2	NUM T1 Sg
+A3	CASE T1 Nom
+A4	OTHER T1 UNK
+T2	A 8 15	Eilinen
+#2	Lemma T2	 eilinen
+A5	NUM T2 Sg
+A6	CASE T2 Nom
+A7	CMP T2 Pos
+A8	CASECHANGE T2 Cap
+T3	N 16 33	Delilah-musikaali
+#3	Lemma T3	 Delilah-musikaali
+A9	NUM T3 Sg
+A10	CASE T3 Nom
+A11	CASECHANGE T3 cap
+A12	OTHER T3 UNK
+T4	V 34 37	oli
+#4	Lemma T4	 olla
+A13	PRS T4 Sg3
+A14	VOICE T4 Act
+A15	TENSE T4 Prt
+A16	MOOD T4 Ind
+A17	CASECHANGE T4 cap
+T5	Adv 38 45	todella
+#5	Lemma T5	 todella
+A18	CASECHANGE T5 cap
+T6	A 46 56	onnistunut
+#6	Lemma T6	 onnistunut
+A19	NUM T6 Sg
+A20	CASE T6 Nom
+A21	CMP T6 Pos
+A22	CASECHANGE T6 cap
+T7	N 57 68	lopputyöksi
+#7	Lemma T7	 loppu|työ
+A23	NUM T7 Sg
+A24	CASE T7 Tra
+A25	CASECHANGE T7 cap
+T8	Punct 69 70	.
+#8	Lemma T8	 .
+R1	punct Arg1:T6 Arg2:T8
+R2	amod Arg1:T3 Arg2:T2
+R3	nommod Arg1:T6 Arg2:T7
+R4	advmod Arg1:T6 Arg2:T5
+R5	cop Arg1:T6 Arg2:T4
+R6	nsubj-cop Arg1:T6 Arg2:T3
+T9	C 71 77	Vaikka
+#9	Lemma T9	 vaikka

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.md', encoding='utf-8') as f:
 
 setup(
     name='bratutils',
-    version='0.2.2',
+    version='0.3.0.dev0',
     packages=find_packages('src', exclude=('tests',)),
     url='https://github.com/savkov/transcriptor',
     author='Sasho Savkov',

--- a/src/bratutils/utils.py
+++ b/src/bratutils/utils.py
@@ -94,6 +94,7 @@ def merge_brat_documents(fp_a, fp_b, fp_res):
     :param fp_b: file path B
     :param fp_res: results file path
     """
+    # TODO: this looks wrong; investigate
     doc1 = BratAnnotation(doc_path=fp_a)
     doc2 = BratAnnotation(doc_path=fp_b)
     merged_doc = BratAnnotation()

--- a/src/tests/test_datastructures.py
+++ b/src/tests/test_datastructures.py
@@ -1,18 +1,3 @@
-# This file is part of bratutils.
-#
-# bratutils is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# bratutils is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with bratutils.  If not, see <http://www.gnu.org/licenses/>.
-
 from unittest import TestCase
 from bratutils.bratdata import *
 
@@ -32,13 +17,13 @@ class TestDataStructures(TestCase):
 
     def test_comment(self):
         c = BratComment(self.commentStr)
-        self.assertEqual(c.id, 1)
-        self.assertEqual(c.recordref, 36)
+        self.assertEqual(c.id, '#1')
+        self.assertEqual(c.recordref, 'T36')
         self.assertEqual(c.note, "Abbreviation for the word increase")
 
     def test_record(self):
         r = BratAnnotation(self.recordStr)
-        self.assertEqual(r.id, 36)
+        self.assertEqual(r.id, 'T36')
         self.assertEqual(r.tag, "MV")
         self.assertEqual(r.boundaries, [["681", "685"]])
         self.assertEqual(r.content, "incr")
@@ -147,14 +132,14 @@ class TestDataStructures(TestCase):
 
     def test_document_get_duplicates(self):
         doc_from_file = BratDocument("res/tests/sampledoc.ann")
-        duplicates = doc_from_file.get_duplicates(1)
-        self.assertListEqual(duplicates, [4])
-        duplicates = doc_from_file.get_duplicates(2)
+        duplicates = doc_from_file.get_duplicates('T1')
+        self.assertListEqual(duplicates, ['T4'])
+        duplicates = doc_from_file.get_duplicates('T2')
         self.assertListEqual(duplicates, [])
-        duplicates = doc_from_file.get_duplicates(3)
-        self.assertListEqual(duplicates, [7])
-        duplicates = doc_from_file.get_duplicates(4)
-        self.assertListEqual(duplicates, [1])
+        duplicates = doc_from_file.get_duplicates('T3')
+        self.assertListEqual(duplicates, ['T7'])
+        duplicates = doc_from_file.get_duplicates('T4')
+        self.assertListEqual(duplicates, ['T1'])
 
     def test_document_removeduplicates(self):
         doc_from_file = BratDocument("res/tests/sampledoc.ann")
@@ -182,3 +167,7 @@ class TestDataStructures(TestCase):
         doc[r6.id] = r6
         doc_from_file.remove_duplicates()
         self.assertDictEqual(doc, doc_from_file)
+
+    def test_unsupported_annotations(self):
+        doc = BratDocument("res/tests/unsupporteddoc.ann")
+        self.assertEqual(9, len(doc.values()))


### PR DESCRIPTION
* ids are now strings rather than integers.
* added another test file copied sample from Turku Treebank
* comments are supported in a better way now
* attributes and relations are ignored

Closes #16 